### PR TITLE
feat: add ==mark== highlight + binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin complements [vim-markdown](https://github.com/tpope/vim-markdown) an
 
 ## Features
 - Work alongside tpope/vim-markdown and lervag/wiki.vim
-- Smart toggling Bold, Italic, Strike and inline Code
+- Smart toggling Bold, Italic, Strike, Mark and inline Code
 - Smart toggling markdown URL Link, Image Link and custom File Link
 - Smart toggling Todo checkbox markers to reflect task status
 - Smart toggling Code Block and Quote Block

--- a/autoload/mplus/constants.vim
+++ b/autoload/mplus/constants.vim
@@ -27,6 +27,9 @@ const BOLD_U_CLOSE_REGEX = '\v\S((\\|_)@<!|(\\_))@<=__(_)@!|^$'
 
 const STRIKE_OPEN_REGEX = '\v((\\|\~)@<!|(\\\~))@<=\~\~(\~)@!\S'
 const STRIKE_CLOSE_REGEX = '\v\S((\\|\~)@<!|(\\\~))@<=\~\~(\~)@!|^$'
+
+const MARK_OPEN_REGEX = '\v((\\|\=)@<!|(\\\=))@<=\=\=(\=)@!\S'
+const MARK_CLOSE_REGEX = '\v\S((\\|\=)@<!|(\\\=))@<=\=\=(\=)@!|^$'
 # TODO: CODEBLOCK REGEX COULD BE IMPROVED
 const CODEBLOCK_OPEN_REGEX = '^```'
 const CODEBLOCK_CLOSE_REGEX = '^```$'
@@ -83,6 +86,9 @@ export const TEXT_STYLES_DICT = {
   markdownStrike: { open_delim: '~~', close_delim: '~~',
   open_regex: STRIKE_OPEN_REGEX, close_regex: STRIKE_CLOSE_REGEX },
 
+  markdownMark: { open_delim: '==', close_delim: '==',
+  open_regex: MARK_OPEN_REGEX, close_regex: MARK_CLOSE_REGEX },
+
   markdownLinkText: { open_delim: '[', close_delim: ']',
   open_regex: LINK_OPEN_REGEX, close_regex: LINK_CLOSE_REGEX },
 
@@ -116,6 +122,10 @@ export const STRIKE_OPEN_DICT = {[TEXT_STYLES_DICT.markdownStrike.open_delim]:
   TEXT_STYLES_DICT.markdownStrike.open_regex}
 export const STRIKE_CLOSE_DICT = {[TEXT_STYLES_DICT.markdownStrike.close_delim]:
   TEXT_STYLES_DICT.markdownStrike.close_regex}
+export const MARK_OPEN_DICT = {[TEXT_STYLES_DICT.markdownMark.open_delim]:
+  TEXT_STYLES_DICT.markdownMark.open_regex}
+export const MARK_CLOSE_DICT = {[TEXT_STYLES_DICT.markdownMark.close_delim]:
+  TEXT_STYLES_DICT.markdownMark.close_regex}
 export const LINK_OPEN_DICT = {[TEXT_STYLES_DICT.markdownLinkText.open_delim]:
   TEXT_STYLES_DICT.markdownLinkText.open_regex}
 export const LINK_CLOSE_DICT = {[TEXT_STYLES_DICT.markdownLinkText.close_delim]:

--- a/doc/markdown_plus.txt
+++ b/doc/markdown_plus.txt
@@ -105,6 +105,7 @@ Visual mappings for the selection:
 - `<localleader>b`: Toggle bold
 - `<localleader>i`: Toggle italic
 - `<localleader>s`: Toggle strikethrough
+- `<localleader>h`: Toggle mark
 - `<localleader>c`: Toggle inline code
 - `<localleader>d`: Remove all text style
 
@@ -119,6 +120,7 @@ Plug mappings (for custom key bindings):
 - `<Plug>MarkdownBold`: Toggle bold formatting
 - `<Plug>MarkdownItalic`: Toggle italic formatting
 - `<Plug>MarkdownStrike`: Toggle strikethrough formatting
+- `<Plug>MarkdownMark`: Toggle mark formatting
 - `<Plug>MarkdownInlineCode`: Toggle inline code formatting
 - `<Plug>MarkdownRemoveAll`: Remove all text style
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -17,6 +17,7 @@ var styles = [
     {plug: '<Plug>MarkdownBold',        key: 'b', style: 'markdownBold'},
     {plug: '<Plug>MarkdownItalic',      key: 'i', style: 'markdownItalic'},
     {plug: '<Plug>MarkdownStrike',      key: 's', style: 'markdownStrike'},
+    {plug: '<Plug>MarkdownMark',        key: 'h', style: 'markdownMark'},
     {plug: '<Plug>MarkdownInlineCode',  key: 'c', style: 'markdownCode'},
     {plug: '<Plug>MarkdownRemoveAll',   key: 'd', style: 'markdownRemoveAll'},
 ]


### PR DESCRIPTION
Hi! This a proposed change containing the addition of the “mark” syntax support in `vim-markdown-plus`.

Since the implementation in this plugin is basically analogous to the one for “strikethrough” `~~`, this PR is pretty straightfoward.

I also added a line in the doc matching the description of the added functionality. I propose the `<localleader>h` default key combination, `h` => `highlight`.

---

Here’s a screenshot of a markdown document, where I could toggle the `markdownMark` highlighting style (**EDIT** added animated gif):

![vim-mark-toggle](https://github.com/user-attachments/assets/b4b7ca46-2a18-416e-9069-cc58489c2a7b)
